### PR TITLE
Don't watch .git folder for udpates.

### DIFF
--- a/jeet.js
+++ b/jeet.js
@@ -41,9 +41,9 @@ app.command('watch').description("Watch the current path and recompile CSS on ch
 	compileSCSS(cssPath);
 	startLiveReload(cssPath)
 	fs.watch(rootPath, function(e, filename) {
-		//var ext = filename.substr(-4);
+		var ext = filename.substr(-4);
 		//if (ext === "html" || ext === ".css")
-		if (livereload) {
+		if (livereload && ext !== ".git") {
 			http.get("http://localhost:35729/changed?files=" + filename);
 		}
 	}); 


### PR DESCRIPTION
When watching a git repository, every time a file gets updated the .git folder also gets updated which makes the whole page reload, which is not needed. ".git" folder should not be "watched"
